### PR TITLE
Added installation instructions for AutoCnet and Anaconda

### DIFF
--- a/Anaconda Installation and Setup.ipynb
+++ b/Anaconda Installation and Setup.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installing Anaconda\n",
+    "\n",
+    "\n",
+    "## Download and setup\n",
+    "\n",
+    "Begin by accessing the Anaconda download website at https://www.continuum.io/downloads .\n",
+    "Choose the appropriate version for your system, this will be the linux version if you are on Fedora.\n",
+    "Next, follow the instructions on Anacondas website for installation onto your system. After the installer has finished, it will ask you if you want to prepend the path to your .bashrc file. You'll want to say yes as this is necessary for the rest of the installation process. If you don't you will need to access your .bashrc file and add\n",
+    "\n",
+    " - export PATH=(path to anaconda file)/anaconda3/bin:$PATH\n",
+    "\n",
+    "Once the installation for Anaconda is finished, you'll need to install pip, a package managment system for software packages written in python.\n",
+    "\n",
+    "- To do this type yum install pip into the command line\n",
+    "\n",
+    "After that finishes installing you'll have the base setup for a new Anaconda environment.\n",
+    "\n",
+    "## Installing Python Packages\n",
+    "\n",
+    "Open a new command window, or bash window and begin by creating a new anaconda environment by typing:\n",
+    " - conda create -n autocnet anaconda\n",
+    " \n",
+    "which establishs an isolated anaconda environtment to hold anything associated with the autocnet installation and then\n",
+    " - source activate autocnet\n",
+    " \n",
+    "this allows for the system to access that isolated anaconda environment.\n",
+    "\n",
+    "After you have setup the environment start installing the various packages listed bellow.\n",
+    "\n",
+    "- conda install nose numpy pillow scipy pandas networkx scikit-image sqlalchemy numexpr dill cython pyyaml\n",
+    "- pip install pvl coverage pysal\n",
+    "- pip instal protobuf==3.0.0b2\n",
+    "- conda install gdal\n",
+    "- conda install -c https://conda.anaconda.org/jlaura opencv3=3.0.0\n",
+    "- conda install -c https://conda.anaconda.org/jlaura h5py gdal\n",
+    "- conda install -c osgeo proj4\n",
+    "- conda upgrade numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/AutoCnet Installation.ipynb
+++ b/AutoCnet Installation.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installing AutoCnet\n",
+    "\n",
+    "To start access https://github.com/USGS-Astrogeology/autocnet and click on download zip on the right side of the screen. This will start a zip download of all the files within the AutoCnet code library.\n",
+    "\n",
+    "When it finishes downloading, extract the files from the folder into whatever directory you want the AutoCnet files to go.\n",
+    "\n",
+    "You have installed AutoCnet and setup your anaconda environment, so you should be good to go."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Instructions for installation (primarily for fedora based machines), can easily add more information and detail. The AutoCnet installation instructions are also somewhat temporary as there is probably a better way to do it.